### PR TITLE
Add check for the module-switch-on-connect.so configuration before running the step 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,19 @@ sudo rm /var/lib/gdm3/.config/systemd/user/sockets.target.wants/pulseaudio.socke
 
 ## 4) Optional: Use hot-plugged devices like Bluetooth or USB automatically
 
-This step aim to enable your headphone to auto-connect to your computer when you start it.
+This step aim to enable your headphone to auto-connect to your computer when you start it. Check if it is already configured with:
 
-For Auto-connect A2DP, edit this file:
+```bash
+cat /etc/pulse/default.pa | grep -B 1 -A 3 'ifexists module-switch-on-connect.so'
+```
+
+If there are no matches for it, start configuring Auto-connect For A2DP editing this file:
+
 ```bash
 sudo nano /etc/pulse/default.pa
 ```
 
-Insert following lines at the end:
+Then insert following lines at the end:
 ```text
 .ifexists module-switch-on-connect.so
 	load-module module-switch-on-connect


### PR DESCRIPTION
# Context

After running the required steps and being able to connect my headphone, I ran the optional steps. 

Then I noticed that step 4) was not necessary as it was already configured for me due to [this issue](https://bugs.launchpad.net/ubuntu/+source/pulseaudio/+bug/1702794):

![image](https://user-images.githubusercontent.com/9122519/210638346-26000db7-2324-40b4-88c6-b1d503790f87.png)

# Suggestion

The idea of this edit is to offer a way for users to check if it was already configured before adding the condition again to the end of the file. Feel free to edit the text/commands!

